### PR TITLE
Update models.py

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -40,7 +40,7 @@ class SparseMatrix(BaseModel):
     def to_numpy(self) -> np.ndarray:
 
         # Depend dtype on the maximum value in the matrix
-        mx = max(map(abs, self.vals), default=1)
+        mx = max(map(abs, self.vals), default=1) * 2
         dtype = np.int8 if mx < 256 else (np.int16 if mx < 32767 else np.int32)
     
         # Create an empty matrix filled with zeros


### PR DESCRIPTION
int8 covers -128 to +127, not -256 to +255. We double the arg condition setting the np dtype dynamically