### PR TITLE
Fix logic to select the appropriate data type

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -96,8 +96,16 @@ class Model(BaseModel):
     
     @model_validator(mode='before')
     def set_columns_from_variables(data: dict):
-        poly_vars = data.get('polyhedron', {}).get('variables', [])
-        poly_A_shape = data.get('polyhedron', {}).get('A', {}).get('shape', {})
+        polyhedron = data.get('polyhedron', {})
+        if isinstance(polyhedron, dict):
+            poly_vars = polyhedron.get('variables', [])
+            poly_A_shape = polyhedron.get('A', {}).get('shape', {})
+        else:
+            poly_vars = polyhedron.variables
+            poly_A_shape = {
+                "nrows": polyhedron.A.shape.nrows,
+                "ncols": polyhedron.A.shape.ncols
+            }
         columns = data.get('columns', [])
         rows = data.get('rows', [])
         intvars = data.get('intvars', [])

--- a/app/models.py
+++ b/app/models.py
@@ -40,8 +40,8 @@ class SparseMatrix(BaseModel):
     def to_numpy(self) -> np.ndarray:
 
         # Depend dtype on the maximum value in the matrix
-        mx = max(map(abs, self.vals), default=1) * 2
-        dtype = np.int8 if mx < 256 else (np.int16 if mx < 32767 else np.int32)
+        mx = max(map(abs, self.vals), default=1)
+        dtype = np.int8 if mx < 127 else (np.int16 if mx < 32767 else np.int32)
     
         # Create an empty matrix filled with zeros
         dense_matrix = np.zeros(self.shape.as_tuple(), dtype=dtype)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -54,16 +54,93 @@ def test_empty_matrix():
     expected_empty = np.zeros((3, 3), dtype=np.int8)
     np.testing.assert_array_equal(dense_matrix, expected_empty)
 
-def test_dtype_selection():
+def test_dtype_selection_large_value_selects_int32():
     large_vals = [10, 200, 40000]
-    large_sparse_matrix = SparseMatrix(
+    sparse_matrix = SparseMatrix(
         rows=[0, 1, 2],
         cols=[0, 1, 2],
         vals=large_vals,
         shape={"nrows": 3, "ncols": 3}
     )
-    dense_matrix = large_sparse_matrix.to_numpy()
+    dense_matrix = sparse_matrix.to_numpy()
     assert dense_matrix.dtype == np.int32
+
+def test_dtype_selection_negative_large_value_selects_int32():
+    large_vals = [10, 200, -40000]
+    sparse_matrix = SparseMatrix(
+        rows=[0, 1, 2],
+        cols=[0, 1, 2],
+        vals=large_vals,
+        shape={"nrows": 3, "ncols": 3}
+    )
+    dense_matrix = sparse_matrix.to_numpy()
+    assert dense_matrix.dtype == np.int32
+
+def test_dtype_selection_medium_value_higher_limit_selects_int16():
+    medium_vals = [10, 20, 32766]
+    sparse_matrix = SparseMatrix(
+        rows=[0, 1, 2],
+        cols=[0, 1, 2],
+        vals=medium_vals,
+        shape={"nrows": 3, "ncols": 3}
+    )
+    dense_matrix = sparse_matrix.to_numpy()
+    assert dense_matrix.dtype == np.int16
+
+def test_dtype_selection_medium_value_lower_limit_selects_int16():
+    medium_vals = [10, 20, 128]
+    sparse_matrix = SparseMatrix(
+        rows=[0, 1, 2],
+        cols=[0, 1, 2],
+        vals=medium_vals,
+        shape={"nrows": 3, "ncols": 3}
+    )
+    dense_matrix = sparse_matrix.to_numpy()
+    assert dense_matrix.dtype == np.int16
+
+def test_dtype_selection_negative_medium_value_higher_limit_selects_int16():
+    medium_vals = [10, 20, -32766]
+    sparse_matrix = SparseMatrix(
+        rows=[0, 1, 2],
+        cols=[0, 1, 2],
+        vals=medium_vals,
+        shape={"nrows": 3, "ncols": 3}
+    )
+    dense_matrix = sparse_matrix.to_numpy()
+    assert dense_matrix.dtype == np.int16
+
+def test_dtype_selection_negative_medium_value_lower_limit_selects_int16():
+    medium_vals = [10, 20, -128]
+    sparse_matrix = SparseMatrix(
+        rows=[0, 1, 2],
+        cols=[0, 1, 2],
+        vals=medium_vals,
+        shape={"nrows": 3, "ncols": 3}
+    )
+    dense_matrix = sparse_matrix.to_numpy()
+    assert dense_matrix.dtype == np.int16
+
+def test_dtype_selection_small_values_selects_int8():
+    small_vals = [10, 20, 126]
+    sparse_matrix = SparseMatrix(
+        rows=[0, 1, 2],
+        cols=[0, 1, 2],
+        vals=small_vals,
+        shape={"nrows": 3, "ncols": 3}
+    )
+    dense_matrix = sparse_matrix.to_numpy()
+    assert dense_matrix.dtype == np.int8
+
+def test_dtype_selection_negative_small_values_selects_int8():
+    small_vals = [10, 20, -126]
+    sparse_matrix = SparseMatrix(
+        rows=[0, 1, 2],
+        cols=[0, 1, 2],
+        vals=small_vals,
+        shape={"nrows": 3, "ncols": 3}
+    )
+    dense_matrix = sparse_matrix.to_numpy()
+    assert dense_matrix.dtype == np.int8
 
 def test_invalid_inputs():
     with pytest.raises(ValidationError):


### PR DESCRIPTION
# Description

The limits for the different NumPy data types here are 
```
Data type | Description
----------+------------
int8      | Byte (-128 to 127)
int16     | Integer (-32768 to 32767)
int32     | Integer (-2147483648 to 2147483647)
```
https://jakevdp.github.io/PythonDataScienceHandbook/02.01-understanding-data-types.html#NumPy-Standard-Data-Types

This fix should lead to that we choose correctly between `np.int16` and `np.int32`.